### PR TITLE
Allow passing more options to the pushy request API call

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,11 +79,11 @@ Pushy.prototype.sendPushNotification = function (data, recipient, options, callb
         }
 
         // Send push using the "request" package
-        request({
+        request(Object.assign({
             uri: that.getApiEndpoint() + '/push?api_key=' + that.apiKey,
             method: 'POST',
             json: postData
-        }, function (err, res, body) {
+        }, this.extraRequestOptions || {}), function (err, res, body) {
             // Request error?
             if (err) {
                 // Send to callback
@@ -129,6 +129,11 @@ Pushy.prototype.setEnterpriseConfig = function (endpoint) {
 // API endpoint selector
 Pushy.prototype.getApiEndpoint = function () {
     return (this.enterpriseEndpoint) ? this.enterpriseEndpoint : apiEndpoint;
+}
+
+// Add extra options that will be passed to the request library
+Pushy.prototype.setExtraRequestOptions = function (extraRequestOptions) {
+    this.extraRequestOptions = extraRequestOptions;
 }
 
 // Expose the Pushy object

--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ Pushy.prototype.sendPushNotification = function (data, recipient, options, callb
             uri: that.getApiEndpoint() + '/push?api_key=' + that.apiKey,
             method: 'POST',
             json: postData
-        }, this.extraRequestOptions || {}), function (err, res, body) {
+        }, that.extraRequestOptions || {}), function (err, res, body) {
             // Request error?
             if (err) {
                 // Send to callback


### PR DESCRIPTION
This PR adds a `setExtraRequestOptions(options)` method to the pushy client. The options get merged in with the options sent to pushy, so it's possible for users of the library to add any extra configuration needed.

The impetus for adding this is so it's possible to use pushy with a http proxy, which the `request` library supports, but `pushy-node` has no way of configuring. For example, this PR allows setting up a http proxy via:

```js
const client = new Pushy('api-key');
client.setExtraRequestOptions({
  proxy: 'http://123.123.123.123:1234',
});
```