### PR TITLE
Make all send push options properties optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -269,7 +269,7 @@ declare module 'pushy' {
         sendPushNotification(
             data: unknown,
             recipient: string | Array<string>,
-            options?: SendPushNotificationOptions,
+            options?: Partial<SendPushNotificationOptions>,
             callback?: (error: Error | null, result: SendPushNotificationResult) => void
         ): Promise<SendPushNotificationResult>;
 


### PR DESCRIPTION
This allows to pass only some options. Without this the method asks to pass all options or none.